### PR TITLE
SlurCutter: Bug fixes and note glide improvements

### DIFF
--- a/src/apps/SlurCutter/gui/DsSentence.h
+++ b/src/apps/SlurCutter/gui/DsSentence.h
@@ -15,13 +15,13 @@ struct DsSentence {
     QString note_slur;
     QString f0_seq;
     QString f0_timestep;
-    QString note_ornament;
+    QString note_glide;
 
     DsSentence() {}
     DsSentence(const QString &text, const QString &ph_seq, const QString &ph_dur, const QString &ph_num,
                const QString &note_seq, const QString &note_dur, const QString &note_slur, const QString &f0_seq,
                const QString &f0_timestep, const QString &note_ornament)
         : text(text), ph_seq(ph_seq), ph_dur(ph_dur), ph_num(ph_num), note_seq(note_seq), note_dur(note_dur),
-          note_slur(note_slur), f0_seq(f0_seq), f0_timestep(f0_timestep), note_ornament(note_ornament) {}
+          note_slur(note_slur), f0_seq(f0_seq), f0_timestep(f0_timestep), note_glide(note_ornament) {}
 };
 QAS_JSON_NS(DsSentence);

--- a/src/apps/SlurCutter/gui/DsSentence.h
+++ b/src/apps/SlurCutter/gui/DsSentence.h
@@ -20,8 +20,8 @@ struct DsSentence {
     DsSentence() {}
     DsSentence(const QString &text, const QString &ph_seq, const QString &ph_dur, const QString &ph_num,
                const QString &note_seq, const QString &note_dur, const QString &note_slur, const QString &f0_seq,
-               const QString &f0_timestep, const QString &note_ornament)
+               const QString &f0_timestep, const QString &note_glide)
         : text(text), ph_seq(ph_seq), ph_dur(ph_dur), ph_num(ph_num), note_seq(note_seq), note_dur(note_dur),
-          note_slur(note_slur), f0_seq(f0_seq), f0_timestep(f0_timestep), note_glide(note_ornament) {}
+          note_slur(note_slur), f0_seq(f0_seq), f0_timestep(f0_timestep), note_glide(note_glide) {}
 };
 QAS_JSON_NS(DsSentence);

--- a/src/apps/SlurCutter/gui/F0Widget.cpp
+++ b/src/apps/SlurCutter/gui/F0Widget.cpp
@@ -279,10 +279,16 @@ F0Widget::ReturnedDsString F0Widget::getSavedDsStrings() {
                             : (std::isnan(i.value.cents)
                                    ? (MidiNoteToNoteName(i.value.pitch) + ' ')
                                    : (PitchToNotePlusCentsString(i.value.pitch + 0.01 * i.value.cents) + ' '));
-        switch (i.value.ornament) {
-            case GlideStyle::None: ret.note_glide += "none "; break;
-            case GlideStyle::Up: ret.note_glide += "up "; break;
-            case GlideStyle::Down: ret.note_glide += "down "; break;
+        if (i.value.isRest) {
+            // rest notes must have no glides
+            ret.note_glide += "none ";
+        }
+        else {
+            switch (i.value.ornament) {
+                case GlideStyle::None: ret.note_glide += "none "; break;
+                case GlideStyle::Up: ret.note_glide += "up "; break;
+                case GlideStyle::Down: ret.note_glide += "down "; break;
+            }
         }
     }
     ret.note_dur = ret.note_dur.trimmed();
@@ -485,7 +491,10 @@ void F0Widget::convertAllRestsToNormal() {
 void F0Widget::setMenuFromCurrentNote() {
     auto note = contextMenuNoteInterval.value;
     noteMenuSetGlideType->setEnabled(!note.isRest);
-    if (!note.isRest) {
+    if (note.isRest) {
+        noteMenuSetGlideNone->setChecked(true);
+    }
+    else {
         if (note.ornament == GlideStyle::None) {
             noteMenuSetGlideNone->setChecked(true);
         }

--- a/src/apps/SlurCutter/gui/F0Widget.cpp
+++ b/src/apps/SlurCutter/gui/F0Widget.cpp
@@ -627,6 +627,14 @@ void F0Widget::paintEvent(QPaintEvent *event) {
                                                 0.01 * (std::isnan(i.value.cents) ? 0 : i.value.cents));
                 }
                 if (i.value.glide != GlideStyle::None) {
+                    /*
+                     * Definitions of glide types which cause the difference
+                     * between prepending and appending:
+                     * 1. Up
+                     * The pitch glides up from the beginning, TOWARDS the main note.
+                     * 2. Down
+                     * The pitch glides down at the end, FROM the main note.
+                     */
                     if (i.value.glide == GlideStyle::Up)
                         noteDescText.prepend("↗");
                     if (i.value.glide == GlideStyle::Down)

--- a/src/apps/SlurCutter/gui/F0Widget.cpp
+++ b/src/apps/SlurCutter/gui/F0Widget.cpp
@@ -82,6 +82,7 @@ F0Widget::F0Widget(QWidget *parent) : QFrame(parent), draggingNoteInterval(0, 0)
     bgMenuModeGlide->setCheckable(true);
     bgMenu->addAction(bgMenuReloadSentence);
     bgMenu->addSeparator();
+    bgMenu->addAction(bgMenu_ModePrompt);
     bgMenu->addAction(bgMenuModeNote);
     bgMenu->addAction(bgMenuModeGlide);
     bgMenu->addSeparator();

--- a/src/apps/SlurCutter/gui/F0Widget.cpp
+++ b/src/apps/SlurCutter/gui/F0Widget.cpp
@@ -288,6 +288,7 @@ F0Widget::ReturnedDsString F0Widget::getSavedDsStrings() {
     ret.note_dur = ret.note_dur.trimmed();
     ret.note_seq = ret.note_seq.trimmed();
     ret.note_slur = ret.note_slur.trimmed();
+    ret.note_glide = ret.note_glide.trimmed();
     return ret;
 };
 

--- a/src/apps/SlurCutter/gui/F0Widget.h
+++ b/src/apps/SlurCutter/gui/F0Widget.h
@@ -28,7 +28,7 @@ public:
         QString note_seq;
         QString note_dur;
         QString note_slur;
-        QString note_ornament;
+        QString note_glide;
     };
     ReturnedDsString getSavedDsStrings();
     bool empty();
@@ -48,7 +48,7 @@ public:
 
 protected:
     struct MiniNote;
-    enum class OrnamentStyle {
+    enum class GlideStyle {
         None,
         Up,
         Down,
@@ -67,7 +67,7 @@ protected:
     void splitNoteUnderMouse();
     void shiftDraggedNoteByPitch(double pitchDelta);
     void setDraggedNotePitch(int pitch);
-    void setDraggedNoteOrnament(OrnamentStyle style);
+    void setDraggedNoteOrnament(GlideStyle style);
 
 protected slots:
     // Data manip (global)
@@ -99,7 +99,7 @@ protected:
         double cents; // nan if no cent deviation
         QString text;
         bool isSlur, isRest;
-        OrnamentStyle ornament;
+        GlideStyle ornament;
 
         // Required by IntervalTree
         bool operator<(const MiniNote &other) const {

--- a/src/apps/SlurCutter/gui/F0Widget.h
+++ b/src/apps/SlurCutter/gui/F0Widget.h
@@ -75,8 +75,10 @@ protected slots:
     void convertAllRestsToNormal();
 
     // (Note)
+    void setMenuFromCurrentNote();
     void mergeCurrentSlurToLeftNode(bool checked);
     void toggleCurrentNoteRest();
+    void setCurrentNoteGlideType(QAction *action);
 
 protected:
 
@@ -163,6 +165,12 @@ protected:
     QMenu *noteMenu;
     QAction *noteMenuMergeLeft;
     QAction *noteMenuToggleRest;
+
+    QAction *noteMenuGlidePrompt;
+    QActionGroup *noteMenuSetGlideType;
+    QAction *noteMenuSetGlideNone;
+    QAction *noteMenuSetGlideUp;
+    QAction *noteMenuSetGlideDown;
 
 private:
     // Private unified methods

--- a/src/apps/SlurCutter/gui/F0Widget.h
+++ b/src/apps/SlurCutter/gui/F0Widget.h
@@ -67,7 +67,7 @@ protected:
     void splitNoteUnderMouse();
     void shiftDraggedNoteByPitch(double pitchDelta);
     void setDraggedNotePitch(int pitch);
-    void setDraggedNoteOrnament(GlideStyle style);
+    void setDraggedNoteGlide(GlideStyle style);
 
 protected slots:
     // Data manip (global)
@@ -99,7 +99,7 @@ protected:
         double cents; // nan if no cent deviation
         QString text;
         bool isSlur, isRest;
-        GlideStyle ornament;
+        GlideStyle glide;
 
         // Required by IntervalTree
         bool operator<(const MiniNote &other) const {
@@ -140,7 +140,7 @@ protected:
     enum {
         None,
         Note,
-        Ornament,
+        Glide,
     } draggingMode, selectedDragMode;
     bool dragging = false;
     bool draggingNoteInCents = false;
@@ -158,7 +158,7 @@ protected:
     QAction *bgMenuShowPitchTextOverlay;
     QAction *bgMenu_ModePrompt;
     QAction *bgMenuModeNote;
-    QAction *bgMenuModeOrnament;
+    QAction *bgMenuModeGlide;
 
     QActionGroup *bgMenuModeGroup;
 

--- a/src/apps/SlurCutter/gui/MainWindow.cpp
+++ b/src/apps/SlurCutter/gui/MainWindow.cpp
@@ -189,6 +189,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 }
 
 MainWindow::~MainWindow() {
+    pullEditedMidi();
     if (QMFs::isFileExist(lastFile)) {
         saveFile(lastFile);
     }

--- a/src/apps/SlurCutter/gui/MainWindow.cpp
+++ b/src/apps/SlurCutter/gui/MainWindow.cpp
@@ -250,7 +250,7 @@ void MainWindow::pullEditedMidi() {
     currentSentence["note_seq"] = editedSentence.note_seq;
     currentSentence["note_slur"] = editedSentence.note_slur;
     currentSentence["note_dur"] = editedSentence.note_dur;
-    currentSentence["note_ornament"] = editedSentence.note_ornament;
+    currentSentence["note_glide"] = editedSentence.note_glide;
 }
 
 void MainWindow::switchFile(bool next) {


### PR DESCRIPTION
- Feature: Add glide type switching to context menu.
- Fix: Rename `note_ornament` to `note_glide`.
- Fix: Trim end of note glide string.
- Fix: Save changes when closing window.